### PR TITLE
Fix non-ASCII characters garbled between stdin/stdout

### DIFF
--- a/dsn_plugin/dsn_plugin/SpeechRecognitionClient.cpp
+++ b/dsn_plugin/dsn_plugin/SpeechRecognitionClient.cpp
@@ -178,7 +178,11 @@ static DWORD WINAPI SpeechRecognitionClientThreadStart(void* ctx) {
 	CreatePipe(&g_hChildStd_IN_Rd, &g_hChildStd_IN_Wr, &saAttr, 0);
 	SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0);
 
-	std::string exePath = g_dllPath.substr(0, g_dllPath.find_last_of("\\/")).append("\\DragonbornSpeaksNaturally.exe");
+	std::string exePath = g_dllPath.substr(0, g_dllPath.find_last_of("\\/"))
+		.append("\\DragonbornSpeaksNaturally.exe")
+		.append(" --encoding UTF-8"); // Let the service set encoding of its stdin/stdout to UTF-8.
+                                    // This can avoid non-ASCII characters (such as Chinese characters) garbled.
+	
 	Log::info("Starting speech recognition service at ");
 	Log::info(exePath);
 

--- a/dsn_plugin/dsn_plugin/SpeechRecognitionClient.cpp
+++ b/dsn_plugin/dsn_plugin/SpeechRecognitionClient.cpp
@@ -197,8 +197,9 @@ static DWORD WINAPI SpeechRecognitionClientThreadStart(void* ctx) {
 	//siStartInfo.hStdError = g_hChildStd_OUT_Wr;
 	siStartInfo.hStdOutput = g_hChildStd_OUT_Wr;
 	siStartInfo.hStdInput = g_hChildStd_IN_Rd;
-	siStartInfo.wShowWindow = SW_SHOWMINNOACTIVE;
+	siStartInfo.wShowWindow = SW_HIDE;
 	siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+	siStartInfo.dwFlags |= STARTF_USESHOWWINDOW;
 
 	bSuccess = CreateProcess(NULL,
 		szCmdline,     // command line 

--- a/dsn_service/dsn_service/CommandList.cs
+++ b/dsn_service/dsn_service/CommandList.cs
@@ -16,6 +16,7 @@ namespace DSN {
             if(sectionData != null) {
                 foreach(KeyData key in sectionData) {
                     Grammar grammar = new Grammar(new GrammarBuilder(key.KeyName));
+                    grammar.Name = key.KeyName;
                     list.commandsByPhrase[grammar] = key.Value.Trim();
                 }
             }
@@ -33,7 +34,7 @@ namespace DSN {
         public void PrintToTrace() {
             Trace.TraceInformation("Command List Phrases:");
             foreach (KeyValuePair<Grammar, string> entry in commandsByPhrase) {
-                Trace.TraceInformation("Phrase '{0}' mapped to commands '{1}'", entry.Key, entry.Value);
+                Trace.TraceInformation("Phrase '{0}' mapped to commands '{1}'", entry.Key.Name, entry.Value);
             }
         }
 

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -48,6 +48,7 @@ namespace DSN {
                     }
 
                     Grammar grammar = new Grammar(grammarBuilder);
+                    grammar.Name = phrase;
                     commandsByGrammar[grammar] = command;
                 } catch(Exception ex) {
                     Trace.TraceError("Failed to parse {0} due to exception:\n{1}", itemStr, ex.ToString());
@@ -60,7 +61,7 @@ namespace DSN {
         public void PrintToTrace() {
             Trace.TraceInformation("Favorites List Phrases:");
             foreach (KeyValuePair<Grammar, string> entry in commandsByGrammar) {
-                Trace.TraceInformation("Phrase '{0}' mapped to equip command '{1}'", entry.Key, entry.Value);
+                Trace.TraceInformation("Phrase '{0}' mapped to equip command '{1}'", entry.Key.Name, entry.Value);
             }
         }
 

--- a/dsn_service/dsn_service/Program.cs
+++ b/dsn_service/dsn_service/Program.cs
@@ -7,9 +7,26 @@ namespace DSN {
         private static readonly string VERSION = "0.14";
 
         static void Main(string[] args) {
-            try {
+            try
+            {
                 Log.Initialize();
                 Trace.TraceInformation("DragonbornSpeaksNaturally ({0}) speech recognition service started", VERSION);
+
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (args[i].Equals("--encoding") && args.Length >= i + 1)
+                    {
+                        string encode = args[i+1];
+
+                        // Set encoding of stdin/stdout to the client specified.
+                        // This can avoid non-ASCII characters (such as Chinese characters) garbled.
+                        Console.InputEncoding = System.Text.Encoding.GetEncoding(encode);
+                        Console.OutputEncoding = System.Text.Encoding.GetEncoding(encode);
+
+                        Trace.TraceInformation("Set encoding of stdin/stdout to {0}", encode);
+                    }
+                }
+
                 Thread skyrimThread = SkyrimInterop.Start();
                 Thread externalThread = ExternalInterop.Start();
 

--- a/dsn_service/dsn_service/SkyrimInterop.cs
+++ b/dsn_service/dsn_service/SkyrimInterop.cs
@@ -67,6 +67,7 @@ namespace DSN {
             try {
                 while (true) {
                     string input = Console.ReadLine();
+                    Trace.TraceInformation("Received command: {0}", input);
 
                     // input will be null when Skyrim is closed
                     if (input == null)

--- a/dsn_service/dsn_service/dsn_service.csproj
+++ b/dsn_service/dsn_service/dsn_service.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DEA491EE-C426-4B79-A443-CF5B1D795288}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <RootNamespace>DSN</RootNamespace>
     <AssemblyName>DragonbornSpeaksNaturally</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>


### PR DESCRIPTION
`dsn_plugin` sent its command as `UTF-8` encoded but `dsn_service` recieved it by `ANSI` (it will be `GBK`/`cp936` when the system language is `Simplified Chinese`). So any non-ASCII characters will be garbled and speech recognition does not work at all when your game language is `Traditional Chinese` or `Simplified Chinese`.

I fixed the issue by adding a new param `--encoding` to `dsn_service` and set it be `UTF-8` when `dsn_plugin` starting the service.

Now `dsn_service` is a console application because a Windows application cannot set `InputEncoding`, a `System.IO.IOException: invalid handle` will be  threw.

And, because `dsn_service` is a console application, we can run it directly and input our commands to test. (Without the param, both console and `dsn_service`'s encoding are `ANSI` so characters garbled will not happen.)

It has no additional disadvantages. I have modified the ` dsn_plugin ` to hide the console window. And when ` Skyrim ` exited, ` dsn_service ` can exit normally.

Now it works well with my SkyrimVR and [Chinese Translation Mod](https://www.nexusmods.com/skyrimspecialedition/mods/1333/). Official Traditional Chinese and English work well too.