### PR TITLE
dsn_service allows to switch audio input device midway.

### DIFF
--- a/dsn_service/dsn_service/Log.cs
+++ b/dsn_service/dsn_service/Log.cs
@@ -22,7 +22,7 @@ namespace DSN {
                 Trace.Listeners.Add(listener);
             }
             catch(Exception ex) {
-                Console.Error.WriteLine("Failed to create log file at " + logFilePath);
+                Console.Error.WriteLine("Failed to create log file at " + logFilePath + ": {0}", ex.ToString());
             }
     
         }

--- a/dsn_service/dsn_service/SkyrimInterop.cs
+++ b/dsn_service/dsn_service/SkyrimInterop.cs
@@ -44,6 +44,7 @@ namespace DSN {
 
         public static void Stop() {
             submissionThread.Abort();
+            recognizer.Stop();
         }
 
         public static void SubmitCommand(string command) {
@@ -67,11 +68,14 @@ namespace DSN {
             try {
                 while (true) {
                     string input = Console.ReadLine();
-                    Trace.TraceInformation("Received command: {0}", input);
 
-                    // input will be null when Skyrim is closed
-                    if (input == null)
+                    // input will be null when Skyrim is terminated
+                    if (input == null) {
+                        Trace.TraceInformation("Skyrim is terminated, recognition service will quit.");
                         break;
+                    }
+
+                    Trace.TraceInformation("Received command: {0}", input);
 
                     string[] tokens = input.Split('|');
                     string command = tokens[0];


### PR DESCRIPTION
When I take off my HDM and drink water and rest, my Bluetooth headset may sleep and the default audio input device will be unavailable. Before this, I must restart the game.

Now it's not need to restart. When the new default audio device is available, dsn_service will automatically recover.

In addition, if the default audio input device does not exist when entering the game, dsn_service will wait for it instead of crashing.

Note: If your microphone is not working properly and cannot record, you may observe a lot of "waiting for available recording device" (once every few seconds). This is not a problem with this commit. If the microphone can record normally, this problem does not occur.

And, SwimmingTiger is YihaoPeng. :joy: