### PR TITLE
Enable configurable replacements for favorites

### DIFF
--- a/DragonbornSpeaksNaturally.SAMPLE.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE.ini
@@ -1,0 +1,75 @@
+[SpeechRecognition]
+; Set this to override your system's default locale
+Locale=en-US
+
+; When set to 1, the speech recognition service will log any audio signal issues like "too loud" or "too noisy"
+bLogAudioSignalIssues=1
+
+; Set these to override the minimum confidence required for matching dialogue and commands (default values are shown here)
+dialogueMinConfidence=0.5
+commandMinConfidence=0.5
+
+[Favorites]
+; Set enabled to 0 to disable the favorites menu voice-equip
+enabled=1
+; Set this to your preferred prefix for equipping items. Can be to set to nothing for no prefix.
+equipPhrasePrefix=equip
+
+; Set this for your language
+leftHandSuffix=left
+rightHandSuffix=right
+
+; Item Name Replacements
+; ======================
+; 
+; The following sections enable the items, spells and shouts names to be changed (only for speach) to make it easier to use them 
+; for voice control 
+;
+; --------
+; Regular Expression replacements. See https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expressions
+;
+; --------
+; Remove contents in squared brackets (for crafting quality modifiers like 'excellent')
+ReplaceRegExPhrase1=\(.*?\)-->
+; Remove Crafted marker from potions
+ReplaceRegExPhrase6=\s\*$-->
+
+; Adaptations for Valdacil's Item Sorting
+; ---------------------------------------
+; Remove square and curled bracket contents
+ReplaceRegExPhrase2=\[.*?\]-->
+ReplaceRegExPhrase3=\|.*?\|-->
+ReplaceRegExPhrase4=\{.*?\}-->
+; Remove magic school and item type prefixed like "Light:"
+ReplaceRegExPhrase5=\b.*\:\s-->
+
+
+; --------
+; Plain Text replacements
+; --------
+; Roman number replacements
+ReplacePhrase1=I-->1
+ReplacePhrase2=II-->2
+ReplacePhrase3=III-->3
+ReplacePhrase4=IV-->4
+ReplacePhrase5=V-->5
+ReplacePhrase6=VI-->6
+ReplacePhrase7=VII-->7
+ReplacePhrase8=VIII-->8
+
+; Other replacements
+ReplacePhrase10=Spellbreaker-->Shield of Spells
+
+
+[Dialogue]
+; These phrases can be said to exit from dialogue
+goodbyePhrases=See ya
+
+[ConsoleCommands]
+; Add any custom console commands here, format is:
+;
+; phrase=console command 1;console command 2;console command 3;
+; 
+; Here are some examples:
+;
+; Give me some gold=player.additem f 100

--- a/dsn_service/dsn_service/Configuration.cs
+++ b/dsn_service/dsn_service/Configuration.cs
@@ -41,7 +41,6 @@ namespace DSN {
         private static IniData merged = null;
         private static CommandList consoleCommandList = null;
         private static List<ReplPhrase> replacePhrases = null;
-        private static List<ReplPhrase> replaceCategoryPhrases = null;
         private static List<ReplPhrase> replaceRegExPhrases = null;
 
         private Configuration() { }
@@ -67,7 +66,6 @@ namespace DSN {
         {
             replacePhrases = new List<ReplPhrase>();
             replaceRegExPhrases = new List<ReplPhrase>();
-            replaceCategoryPhrases = new List<ReplPhrase>();
 
             KeyDataCollection keyCollection = merged["Favorites"];
 
@@ -76,10 +74,6 @@ namespace DSN {
                 if (keyData.KeyName.StartsWith("ReplacePhrase"))
                 {
                     replacePhrases.Add(new ReplPhrase(keyData.Value));
-                }
-                if (keyData.KeyName.StartsWith("ReplaceCategoryPhrase"))
-                {
-                    replaceCategoryPhrases.Add(new ReplPhrase(keyData.Value));
                 }
                 else if (keyData.KeyName.StartsWith("ReplaceRegExPhrase"))
                 {
@@ -98,12 +92,6 @@ namespace DSN {
         {
             getData();
             return replaceRegExPhrases;
-        }
-
-        public static List<ReplPhrase> GetReplaceCategoryPhrases()
-        {
-            getData();
-            return replaceCategoryPhrases;
         }
 
         public static CommandList GetConsoleCommandList() {

--- a/dsn_service/dsn_service/Configuration.cs
+++ b/dsn_service/dsn_service/Configuration.cs
@@ -10,6 +10,22 @@ using System.Threading.Tasks;
 
 namespace DSN {
 
+    public class ReplPhrase
+    {
+        public string pattern = "";
+        public string replacement = "";
+
+        public ReplPhrase(string input)
+        {
+            string[] tokens = input.Split(new string[] {"-->"},2,StringSplitOptions.None);
+            pattern = tokens[0];
+            if (tokens.Length > 1)
+                replacement = tokens[1];
+
+            Trace.TraceInformation("replacePhrase: " + pattern + " with " + replacement);
+        }
+    }
+
     class Configuration {
         private static readonly string CONFIG_FILE_NAME = "DragonbornSpeaksNaturally.ini";
         private static readonly string COMMAND_FILE_NAME = "DragonbornSpeaksNaturally.ini";
@@ -24,6 +40,9 @@ namespace DSN {
         private static IniData local = null;
         private static IniData merged = null;
         private static CommandList consoleCommandList = null;
+        private static List<ReplPhrase> replacePhrases = null;
+        private static List<ReplPhrase> replaceCategoryPhrases = null;
+        private static List<ReplPhrase> replaceRegExPhrases = null;
 
         private Configuration() { }
 
@@ -42,6 +61,49 @@ namespace DSN {
                 return list;
             }
             return new List<string>();
+        }
+
+        public static void LoadReplacePhrases()
+        {
+            replacePhrases = new List<ReplPhrase>();
+            replaceRegExPhrases = new List<ReplPhrase>();
+            replaceCategoryPhrases = new List<ReplPhrase>();
+
+            KeyDataCollection keyCollection = merged["Favorites"];
+
+            foreach (var keyData in keyCollection)
+            {
+                if (keyData.KeyName.StartsWith("ReplacePhrase"))
+                {
+                    replacePhrases.Add(new ReplPhrase(keyData.Value));
+                }
+                if (keyData.KeyName.StartsWith("ReplaceCategoryPhrase"))
+                {
+                    replaceCategoryPhrases.Add(new ReplPhrase(keyData.Value));
+                }
+                else if (keyData.KeyName.StartsWith("ReplaceRegExPhrase"))
+                {
+                    replaceRegExPhrases.Add(new ReplPhrase(keyData.Value));
+                }
+            }
+        }
+
+        public static List<ReplPhrase> GetReplacePhrases()
+        {
+            getData();
+            return replacePhrases;
+        }
+
+        public static List<ReplPhrase> GetReplaceRegExPhrases()
+        {
+            getData();
+            return replaceRegExPhrases;
+        }
+
+        public static List<ReplPhrase> GetReplaceCategoryPhrases()
+        {
+            getData();
+            return replaceCategoryPhrases;
         }
 
         public static CommandList GetConsoleCommandList() {
@@ -68,6 +130,7 @@ namespace DSN {
                 merged = new IniData();
                 merged.Merge(global);
                 merged.Merge(local);
+                LoadReplacePhrases();
             }
 
             return merged;

--- a/dsn_service/dsn_service/Phrases.cs
+++ b/dsn_service/dsn_service/Phrases.cs
@@ -4,17 +4,42 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace DSN {
     class Phrases {
-        public static string normalize(string phrase) {
-            phrase = Regex.Replace(phrase, @"\(.*?\)", string.Empty);
+        public static string normalize(string phrase)
+        {
+            Regex regex = new Regex("[ ]{2,}", RegexOptions.None);
+            phrase = regex.Replace(phrase, " ");
+
+            List<ReplPhrase> replacePhrases = Configuration.GetReplacePhrases();
+            List<ReplPhrase> replaceRegExPhrases = Configuration.GetReplaceRegExPhrases();
+            List<ReplPhrase> replaceCategoryPhrases = Configuration.GetReplaceCategoryPhrases();
+
+            foreach (ReplPhrase replacePhrase in replaceRegExPhrases)
+            {
+                phrase = Regex.Replace(phrase, replacePhrase.pattern, replacePhrase.replacement);
+            }
+
+            foreach (ReplPhrase replacePhrase in replaceCategoryPhrases)
+            {
+                string pattern = @"\b(" + replacePhrase.pattern + @")\:";
+                // Trace.TraceInformation("Trying to replace " + pattern + " with " + replacePhrase.replacement);
+                phrase = Regex.Replace(phrase, pattern, replacePhrase.replacement);
+            }
+
+            foreach (ReplPhrase replacePhrase in replacePhrases)
+            {
+                string pattern = @"\b(" + replacePhrase.pattern + @")\b";
+                // Trace.TraceInformation("Trying to replace " + pattern + " with " + replacePhrase.replacement);
+                phrase = Regex.Replace(phrase, pattern, replacePhrase.replacement);
+            }
+
             phrase = Regex.Replace(phrase, "[\"']", string.Empty);
             phrase = phrase.Replace('-', ' ');
-            RegexOptions options = RegexOptions.None;
-            Regex regex = new Regex("[ ]{2,}", options);
-            phrase = regex.Replace(phrase, " ");
             return phrase.Trim();
+
         }
     }
 }

--- a/dsn_service/dsn_service/Phrases.cs
+++ b/dsn_service/dsn_service/Phrases.cs
@@ -15,18 +15,10 @@ namespace DSN {
 
             List<ReplPhrase> replacePhrases = Configuration.GetReplacePhrases();
             List<ReplPhrase> replaceRegExPhrases = Configuration.GetReplaceRegExPhrases();
-            List<ReplPhrase> replaceCategoryPhrases = Configuration.GetReplaceCategoryPhrases();
 
             foreach (ReplPhrase replacePhrase in replaceRegExPhrases)
             {
                 phrase = Regex.Replace(phrase, replacePhrase.pattern, replacePhrase.replacement);
-            }
-
-            foreach (ReplPhrase replacePhrase in replaceCategoryPhrases)
-            {
-                string pattern = @"\b(" + replacePhrase.pattern + @")\:";
-                // Trace.TraceInformation("Trying to replace " + pattern + " with " + replacePhrase.replacement);
-                phrase = Regex.Replace(phrase, pattern, replacePhrase.replacement);
             }
 
             foreach (ReplPhrase replacePhrase in replacePhrases)


### PR DESCRIPTION
Added a feature to allow the 'favorites' replacements to be configured. 

The replacement terms are added to the config file "DragonbonSpeaksNaturally.ini"

Added an example config file customized for the names created by Valdicils' Item Sorter (which also works fine without this). 

If you like this and accept the pull request, I'd be happy to write an explanation for the users. I have many more ideas for this mod. 