### PR TITLE
fix VR screen blink when pick up/discard more than one items quickly.

### DIFF
--- a/dsn_plugin/dsn_plugin/FavoritesMenuManager.cpp
+++ b/dsn_plugin/dsn_plugin/FavoritesMenuManager.cpp
@@ -171,7 +171,11 @@ void FavoritesMenuManager::RefreshFavorites() {
 			FavoriteMenuItem favorite = favorites[i];
 			command += "|" + favorite.fullname + "," + std::to_string(favorite.TESFormId) + "," + std::to_string(favorite.itemId) + "," + std::to_string(favorite.isHanded) + "," + std::to_string(favorite.itemType);
 		}
-		SpeechRecognitionClient::getInstance()->WriteLine(command);
+
+		if (lastFavoritesCommand != command) {
+			SpeechRecognitionClient::getInstance()->WriteLine(command);
+			lastFavoritesCommand = command;
+		}
 	}
 }
 

--- a/dsn_plugin/dsn_plugin/FavoritesMenuManager.h
+++ b/dsn_plugin/dsn_plugin/FavoritesMenuManager.h
@@ -38,4 +38,5 @@ public:
 private:
 	FavoritesMenuManager();
 	std::vector<FavoriteMenuItem> favorites;
+	std::string lastFavoritesCommand;
 };


### PR DESCRIPTION
I encountered a problem that bothers me. Whenever I pick up items continuously or put items in boxes continuously, the screen will blink sometimes.

I know this blink means that the program is not responding. That is, the program did not draw the VR world within the time specified by SteamVR, causing SteamVR to display a blank screen. That is, the program performs a blocking operation.

Then I noticed that whenever I pick up an item, or place an item into the box, dsn_service will always receive a FAVORITES command, even though it is the same as the last one received.

So I think that sending commands frequently is the cause of blocking. This may be specifically `SpeechRecognitionClient::getInstance()->WriteLine(command);` will block before the receiver has processed the previous command.

I added a simple piece of code to avoid unnecessary resending. Now the blink disappears.