### PR TITLE
Phrases.normalize now filters out text enclosed by []

### DIFF
--- a/dsn_service/dsn_service/Phrases.cs
+++ b/dsn_service/dsn_service/Phrases.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace DSN {
     class Phrases {
         public static string normalize(string phrase) {
-            phrase = Regex.Replace(phrase, @"\(.*?\)", string.Empty);
+            phrase = Regex.Replace(phrase, @"\[.*?\]|\(.*?\)", string.Empty);
             phrase = Regex.Replace(phrase, "[\"']", string.Empty);
             phrase = phrase.Replace('-', ' ');
             RegexOptions options = RegexOptions.None;


### PR DESCRIPTION
Howdy!

This patch is meant to be filter out category names enclosed by brackets that may look like:
```
[D1] Unbound Fire
```
This makes selecting items on the favorites menu with DSN very hard. This patch just extends the processing that's already done for text enclosed by () so that text enclosed by [] is ignored also.

I'm not very familiar with the codebase, but initial testing lets me select the spells without issue.