### PR TITLE
Fixes bug where equip commands are not parsed correctly

### DIFF
--- a/dsn_plugin/dsn_plugin/FavoritesMenuManager.cpp
+++ b/dsn_plugin/dsn_plugin/FavoritesMenuManager.cpp
@@ -192,8 +192,11 @@ static std::vector<std::string> split(const std::string &s, char delim) {
 EquipItem parseEquipItem(std::string command) {
 	std::vector<std::string> tokens = split(command, ';');
 
+	char* formId = (char*)tokens[0].c_str();
+	char* end = formId + strlen(formId);
+
 	EquipItem item = {
-		(UInt32)std::atoi(tokens[0].c_str()),
+		(UInt32)std::strtoul(formId, &end, 10),
 		(SInt32)std::atoi(tokens[1].c_str()),
 		(UInt8)std::atoi(tokens[2].c_str()),
 		(SInt32)std::atoi(tokens[3].c_str())


### PR DESCRIPTION
More specifically, parseEquipItem was parsing formIds as signed integers
using atoi(). When the number parsed surpasses 0x7fffffff, it will be
capped there. This will cause the formId lookup to fail and for the
equip command to not run.  The nature of this bug means it will only show
up when the thing being equipped is from an esp with a mod index >=128.

This commit fixes this issue by using strtoul().

The bug was reported here: https://www.reddit.com/r/skyrimvr/comments/9ssm08/psa_apocalypse_and_dragonborn_speaks_naturally/