### PR TITLE
Fixes equip hand suffix settings not used bug

### DIFF
--- a/DragonbornSpeaksNaturally.SAMPLE.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE.ini
@@ -16,11 +16,12 @@ enabled=1
 equipPhrasePrefix=equip
 
 ; Set this for your language
-leftHandSuffix=left
-rightHandSuffix=right
-bothHandsSuffix=both
+equipLeftSuffix=off
+equipRightSuffix=main
+equipBothSuffix=both
 
 ; Which hand to put single handed items in by default?
+; Valid values are "right", "left", "both"
 mainHand=right
 
 [Dialogue]

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -147,9 +147,9 @@ namespace DSN {
         public string GetCommandForResult(RecognitionResult result) {
             var handednessMap = new Dictionary<string, string>
             {
-                { "both", "0" },
-                { "right", "1" },
-                { "left", "2" },
+                { bothHandsSuffix, "0" },
+                { rightHandSuffix, "1" },
+                { leftHandSuffix, "2" },
             };
 
             Grammar grammar = result.Grammar;


### PR DESCRIPTION
Apparently, I broke something during a refactor in #6. This small patch fixes it.

~~Another related issue... The ini settings "leftHandSuffix" and friends were renamed to "equipLeftSuffix". I cannot remember why this was done. In retrospect, this seems like a bad idea since it might break people's existing configs. Should I change that back?~~

(After some digging, the ini setting had always been named "equipLeftSuffix", see 3529441)