### PR TITLE
Automatically reload the configuration file (and some other updates)

### DIFF
--- a/DragonbornSpeaksNaturally.SAMPLE.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE.ini
@@ -35,10 +35,98 @@ mainHand=right
 goodbyePhrases=I'll talk to you later;That's enough chit chat for now
 
 [ConsoleCommands]
-; Add any custom console commands here, format is:
-;
-; phrase=console command 1;console command 2;console command 3;
-; 
-; Here are some examples:
+;;;
+;;; Add any custom console commands here, format is:
+;;;
+;;;    phrase=console command 1;console command 2;console command 3;
+;;;
+;;; Here is a reference manual on the commands available in Skyrim:
+;;;    https://en.uesp.net/wiki/Skyrim:Console
+;;;
+;;; Here are some examples:
+;;; (Remove the ';' to enable these commands)
+;;;
 
-Give me some gold=player.additem f 100
+;Give me some gold=player.additem f 100
+;Toggle god mode=tgm
+;Die Die Die=killall
+
+;;;
+;;; You can also equip/cast specified item/spell/shout directly by command.
+;;;
+;;; You can find more items/spells/shouts' ID here:
+;;;    https://en.uesp.net/wiki/Skyrim:Items
+;;;    https://en.uesp.net/wiki/Skyrim:Spells
+;;;    https://en.uesp.net/wiki/Skyrim:Dragon_Shouts
+;;;
+
+;Ready to battle=player.equipitem 139af; player.equipshout 48ac9
+;Shoot the dragon down=player.equipshout 44250; player.equipitem 139ad
+;I need treatment=player.equipspell 12fcc left; player.equipspell 12fcc right; player.cast 12fcc player left; player.cast 12fcc player right
+;I need quick treatment!=player.equipspell 0002f3b8 left; player.equipspell 0002f3b8 right; player.cast 0002f3b8 player left; player.cast 0002f3b8 player right
+
+;;; 
+;;; For a shout's command phrase, use a similar English spelling to improve the recognition rate.
+;;; 
+;;; You can find more shouts' spell ID from the subpage of the page:
+;;;    https://en.uesp.net/wiki/Skyrim:Dragon_Shouts
+;;; 
+;;; Note that the ID below the shout name is not its spell ID and
+;;; can only be used with the equipitem command and not for the cast command.
+;;; You must click the shout name to go to the subpage and copy the value under the "Spell ID" title.
+;;; A shout corresponds to three spell IDs (with 1 to 3 power words).
+;;;
+
+;Fus Loda=player.cast 00013f3a player voice
+;Force Loda=player.cast 00013f3a player voice
+;Fuse Loda=player.cast 00013f3a player voice
+;Your Tooso=player.cast 0003f9ed player voice
+;Lok Vakoor=player.cast 0003f50d player voice
+;Gol Hadov=player.cast 040179e1 player voice
+
+;;;
+;;; Here are some examples of using keypresses as commands
+;;;
+;;; The following commands can only be used in DSN and are executed by DSN itself.
+;;; You can't use them in the Skyrim console. There are:
+;;;
+;;;    press, tapkey, holdkey, releasekey, sleep and switchwindow.
+;;;
+;;; Here is a document for these commands:
+;;;    https://github.com/DougHamil/DragonbornSpeaksNaturally/wiki/Key-Commands-Guide
+;;;
+;;; Some examples:
+;;;
+
+;Open Map=press m
+;Close Map=press m
+;What should I do=press j
+;I don't want any more=press esc
+;Hello, man=press e
+;Hello, brother=press e
+;I want this=press e
+;Casting a shout=press z 3000
+
+;;;
+;;; Some more complicated examples of combined keypress scripts 
+;;;
+
+;Sneak and cancel=press ctrl; sleep 5000; press ctrl
+;Fire in the hole=player.cast 0003f9ed player voice; sleep 3000; player.cast 00013f3a player voice
+;Casting with two hands=holdkey leftmousebutton; sleep 1000; holdkey rightmousebutton; sleep 5000; releasekey leftmousebutton; sleep 3000; releasekey rightmousebutton
+;Typing in console=switchwindow; sleep 50; tapkey ~; sleep 50; tapkey s a v e; tapkey blank 1; sleep 300; tapkey enter; sleep 3000; tapkey ~
+
+;;;
+;;; Keypress commands in SkyrimVR
+;;;
+;;; All SSE keyboard shortcuts are available in SkyrimVR, so you can use the "press" command
+;;; to do everything in SkyrimVR just likes in SSE, including to cast a left or right hand skill.
+;;; But you have to make sure the game is the active window when a "press" command running.
+;;; If it is not always, you can add the "switchwindow" command before each command.
+;;;
+
+;Sneak and cancel in VR=switchwindow; press ctrl; sleep 5000; press ctrl
+;Left Hand Magic=switchwindow; press leftmousebutton 5000
+;Right Hand Magic=switchwindow; press rightmousebutton 5000
+;Use something=switchwindow; press e
+;Casting a shout in VR=switchwindow; press z 3000

--- a/DragonbornSpeaksNaturally.SAMPLE.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE.ini
@@ -20,8 +20,14 @@ equipLeftSuffix=off
 equipRightSuffix=main
 equipBothSuffix=both
 
+; Consider the above equipLeft/Right/BothSuffix as a prefix instead of a suffix.
+; If enabled, equip phrases will be "off/main/both equip xxx" instead of "equip xxx off/main/both".
+; Open according to your preferences. This may be more convenient in some languages.
+; In addition, you can set equipPhrasePrefix to empty to make better use of hands prefix.
+useEquipHandPrefix=0
+
 ; Which hand to put single handed items in by default?
-; Valid values are "right", "left", "both"
+; Valid values are "right", "left", "both" or the value of equipLeft/Right/BothSuffix your specified.
 mainHand=right
 
 [Dialogue]

--- a/dsn_service/dsn_service/Configuration.cs
+++ b/dsn_service/dsn_service/Configuration.cs
@@ -11,30 +11,30 @@ using System.Threading.Tasks;
 namespace DSN {
 
     class Configuration {
-        private static readonly string CONFIG_FILE_NAME = "DragonbornSpeaksNaturally.ini";
-        private static readonly string COMMAND_FILE_NAME = "DragonbornSpeaksNaturally.ini";
+        private readonly string CONFIG_FILE_NAME = "DragonbornSpeaksNaturally.ini";
+        private readonly string COMMAND_FILE_NAME = "DragonbornSpeaksNaturally.ini";
 
         // NOTE: Relative to SkyrimVR.exe
-        private static readonly string[] SEARCH_DIRECTORIES = {
+        private readonly string[] SEARCH_DIRECTORIES = {
             "Data\\Plugins\\Sumwunn\\",
             ""
         };
 
-        private static IniData global = null;
-        private static IniData local = null;
-        private static IniData merged = null;
-        private static CommandList consoleCommandList = null;
+        private IniData global = null;
+        private IniData local = null;
+        private IniData merged = null;
+        private CommandList consoleCommandList = null;
 
-        private Configuration() { }
+        public Configuration() { }
 
-        public static string Get(string section, string key, string def) {
+        public string Get(string section, string key, string def) {
             string val = getData()[section][key];
             if (val == null)
                 return def;
             return val;
         }
 
-        public static List<string> GetGoodbyePhrases() {
+        public List<string> GetGoodbyePhrases() {
             string phrases = merged["Dialogue"]["goodbyePhrases"];
             if(phrases != null) {
                 List<string> list = new List<string>(phrases.Split(';'));
@@ -44,7 +44,7 @@ namespace DSN {
             return new List<string>();
         }
 
-        public static CommandList GetConsoleCommandList() {
+        public CommandList GetConsoleCommandList() {
             if(consoleCommandList != null)
                 return consoleCommandList;
 
@@ -61,7 +61,7 @@ namespace DSN {
             return consoleCommandList;
         }
 
-        private static IniData getData() {
+        private IniData getData() {
             if (merged == null) {
                 loadLocal();
                 loadGlobal();
@@ -73,19 +73,19 @@ namespace DSN {
             return merged;
         }
 
-        private static void loadGlobal() {
+        private void loadGlobal() {
             global = new IniData();
             // global["SpeechRecognition"]["Locale"] = "en-US";
         }
 
-        private static void loadLocal() {
+        private void loadLocal() {
 
             local = loadIniFromFilename(CONFIG_FILE_NAME);
             if (local == null)
                 local = new IniData();
         }
 
-        public static string resolveFilePath(string filename) {
+        public string resolveFilePath(string filename) {
             foreach (string directory in SEARCH_DIRECTORIES) {
                 string filepath = directory + filename;
                 if (File.Exists(filepath)) {
@@ -95,7 +95,7 @@ namespace DSN {
             return null;
         }
 
-        private static IniData loadIniFromFilename(string filename) {
+        private IniData loadIniFromFilename(string filename) {
             string filepath = resolveFilePath(filename);
             if (filepath != null) {
                 Trace.TraceInformation("Loading ini from path " + filepath);

--- a/dsn_service/dsn_service/Configuration.cs
+++ b/dsn_service/dsn_service/Configuration.cs
@@ -12,7 +12,6 @@ namespace DSN {
 
     class Configuration {
         private readonly string CONFIG_FILE_NAME = "DragonbornSpeaksNaturally.ini";
-        private readonly string COMMAND_FILE_NAME = "DragonbornSpeaksNaturally.ini";
 
         // NOTE: Relative to SkyrimVR.exe
         private readonly string[] SEARCH_DIRECTORIES = {
@@ -23,6 +22,7 @@ namespace DSN {
         private IniData global = null;
         private IniData local = null;
         private IniData merged = null;
+        private List<string> goodbyePhrases = null;
         private CommandList consoleCommandList = null;
 
         public Configuration() { }
@@ -35,28 +35,26 @@ namespace DSN {
         }
 
         public List<string> GetGoodbyePhrases() {
-            string phrases = merged["Dialogue"]["goodbyePhrases"];
-            if(phrases != null) {
-                List<string> list = new List<string>(phrases.Split(';'));
-                list.RemoveAll((str) => str == null || str.Trim() == "");
-                return list;
+            if (goodbyePhrases == null) {
+                goodbyePhrases = new List<string>();
+
+                string phrases = getData()["Dialogue"]["goodbyePhrases"];
+                if (phrases != null) {
+                    goodbyePhrases.AddRange(phrases.Split(';'));
+                    goodbyePhrases.RemoveAll((str) => str == null || str.Trim() == "");
+                }
             }
-            return new List<string>();
+
+            return goodbyePhrases;
         }
 
         public CommandList GetConsoleCommandList() {
-            if(consoleCommandList != null)
-                return consoleCommandList;
+            if (consoleCommandList == null) {
+                consoleCommandList = CommandList.FromIniSection(getData(), "ConsoleCommands");
 
-            IniData commandData = loadIniFromFilename(COMMAND_FILE_NAME);
-            if(commandData != null) {
-                consoleCommandList = CommandList.FromIniSection(commandData, "ConsoleCommands");
-            } else {
-                consoleCommandList = new CommandList();
+                Trace.TraceInformation("Loaded Console Commands:");
+                consoleCommandList.PrintToTrace();
             }
-
-            Trace.TraceInformation("Loaded Console Commands:");
-            consoleCommandList.PrintToTrace();
 
             return consoleCommandList;
         }
@@ -79,7 +77,6 @@ namespace DSN {
         }
 
         private void loadLocal() {
-
             local = loadIniFromFilename(CONFIG_FILE_NAME);
             if (local == null)
                 local = new IniData();

--- a/dsn_service/dsn_service/Configuration.cs
+++ b/dsn_service/dsn_service/Configuration.cs
@@ -66,8 +66,7 @@ namespace DSN {
         public CommandList GetConsoleCommandList() {
             if (consoleCommandList == null) {
                 consoleCommandList = CommandList.FromIniSection(merged, "ConsoleCommands");
-
-                Trace.TraceInformation("Loaded Console Commands:");
+                
                 consoleCommandList.PrintToTrace();
             }
 

--- a/dsn_service/dsn_service/ConsoleInput.cs
+++ b/dsn_service/dsn_service/ConsoleInput.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Speech.Recognition;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DSN
+{
+    class ConsoleInput
+    {
+
+        private BlockingCollection<string> inputQueue = new BlockingCollection<string>();
+        private Thread inputThread = null;
+        bool isInputTerminated = false;
+
+        public void Start()
+        {
+            inputThread = new Thread(ReadLineFromConsole);
+            inputThread.Start();
+        }
+
+        private void ReadLineFromConsole()
+        {
+            while (true)
+            {
+                string input = Console.ReadLine();
+
+                // input will be null when Skyrim terminated (stdin closed)
+                if (input == null)
+                {
+                    isInputTerminated = true;
+                    Trace.TraceInformation("Skyrim is terminated, recognition service will quit.");
+
+                    // Notify the SkyrimInterop thread to exit
+                    inputQueue.Add(null);
+
+                    break;
+                }
+
+                inputQueue.Add(input);
+            }
+        }
+
+        public bool IsInputTerminated() {
+            return isInputTerminated;
+        }
+
+        public void WriteLine(string line) {
+            inputQueue.Add(line);
+        }
+
+        public string ReadLine() {
+            return inputQueue.Take();
+        }
+    }
+}

--- a/dsn_service/dsn_service/ConsoleInput.cs
+++ b/dsn_service/dsn_service/ConsoleInput.cs
@@ -17,6 +17,10 @@ namespace DSN
         private Thread inputThread = null;
         bool isInputTerminated = false;
 
+        // Saved state, used to restore after reloading the configuration file.
+        public string currentDialogue = null;
+        public string currentFavoritesList = null;
+
         public void Start()
         {
             inputThread = new Thread(ReadLineFromConsole);
@@ -55,6 +59,15 @@ namespace DSN
 
         public string ReadLine() {
             return inputQueue.Take();
+        }
+
+        public void RestoreSavedState() {
+            if (currentFavoritesList != null) {
+                inputQueue.Add(currentFavoritesList);
+            }
+            if (currentDialogue != null) {
+                inputQueue.Add(currentDialogue);
+            }
         }
     }
 }

--- a/dsn_service/dsn_service/DialogueList.cs
+++ b/dsn_service/dsn_service/DialogueList.cs
@@ -9,24 +9,29 @@ namespace DSN {
 
         private static readonly SubsetMatchingMode DEFAULT_GRAMMAR_MATCHING_MODE = SubsetMatchingMode.OrderedSubsetContentRequired;
 
-        public static DialogueList Parse(string input) {
+        Configuration config;
+
+        public static DialogueList Parse(string input, Configuration config) {
             string[] tokens = input.Split('|');
             long id = long.Parse(tokens[0]);
             List<string> lines = new List<string>();
             for(int i = 1; i < tokens.Length; i++) {
                 lines.Add(Phrases.normalize(tokens[i]));
             }
-            return new DialogueList(id, lines, Configuration.GetGoodbyePhrases());
+            return new DialogueList(id, lines, config);
         }
 
         public long id { get; private set; }
         private Dictionary<Grammar, int> grammarToIndex = new Dictionary<Grammar, int>();
 
-        private DialogueList(long id, List<string> lines, List<string> goodbyePhrases) {
+        private DialogueList(long id, List<string> lines, Configuration config) {
             this.id = id;
-            SubsetMatchingMode matchingMode = getConfiguredMatchingMode();
+            this.config = config;
 
-            for(int i = 0; i < lines.Count; i++) {
+            SubsetMatchingMode matchingMode = getConfiguredMatchingMode();
+            List<string> goodbyePhrases = config.GetGoodbyePhrases();
+
+            for (int i = 0; i < lines.Count; i++) {
                 string line = lines[i];
                 if (line == null || line.Trim() == "")
                     continue;
@@ -71,7 +76,7 @@ namespace DSN {
         }
         private SubsetMatchingMode getConfiguredMatchingMode() {
 
-            string matchingMode = Configuration.Get("SpeechRecognition", "SubsetMatchingMode", Enum.GetName(typeof(SubsetMatchingMode), DEFAULT_GRAMMAR_MATCHING_MODE));
+            string matchingMode = config.Get("SpeechRecognition", "SubsetMatchingMode", Enum.GetName(typeof(SubsetMatchingMode), DEFAULT_GRAMMAR_MATCHING_MODE));
 
             try {
                 return (SubsetMatchingMode)Enum.Parse(typeof(SubsetMatchingMode), matchingMode, true);

--- a/dsn_service/dsn_service/DialogueList.cs
+++ b/dsn_service/dsn_service/DialogueList.cs
@@ -9,7 +9,7 @@ namespace DSN {
 
         private static readonly SubsetMatchingMode DEFAULT_GRAMMAR_MATCHING_MODE = SubsetMatchingMode.OrderedSubsetContentRequired;
 
-        Configuration config;
+        private Configuration config;
 
         public static DialogueList Parse(string input, Configuration config) {
             string[] tokens = input.Split('|');

--- a/dsn_service/dsn_service/ExternalInterop.cs
+++ b/dsn_service/dsn_service/ExternalInterop.cs
@@ -10,59 +10,107 @@ using System.Threading.Tasks;
 namespace DSN {
     class ExternalInterop {
 
-        SkyrimInterop skyrimInterop;
+        Configuration config = null;
+        SkyrimInterop skyrimInterop = null;
 
         private readonly HashSet<string> BATCH_FILENAMES = new HashSet<string>() { "wotv", "ivrqs" };
         private readonly long FILE_CHANGE_DEBOUNCE_TIME_TICKS = 10000 * 200; // 200 ms
 
-        private FileSystemWatcher watcher;
-        private DateTime lastChangeDt = DateTime.Now;
+        private FileSystemWatcher batchDirWatcher;
+        private DateTime batchDirLastChangeDt = DateTime.Now;
+
+        private string configFileName = null;
+        private FileSystemWatcher configFileWatcher;
+        private bool isConfigFileChanged = false;
 
 
-        public ExternalInterop(SkyrimInterop skyrimInterop) {
+        public ExternalInterop(Configuration config, SkyrimInterop skyrimInterop) {
+            this.config = config;
             this.skyrimInterop = skyrimInterop;
         }
 
-        public Thread Start() {
-            Thread thread = new Thread(ListenForInput);
-            thread.Start();
-            return thread;
+        public void Start() {
+            ListenForBatchDir();
+            ListenForConfigFile();
         }
 
         public void Stop() {
-            watcher.EnableRaisingEvents = false;
+            batchDirWatcher.EnableRaisingEvents = false;
+            configFileWatcher.EnableRaisingEvents = false;
         }
 
-        private void ListenForInput() {
+        private void ListenForBatchDir() {
             try {
-                string exepath = System.IO.Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
-                Trace.TraceInformation(exepath);
-                watcher = new FileSystemWatcher();
-                watcher.Path = Directory.GetCurrentDirectory();
-                watcher.Changed += Watcher_Changed;
-                watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
-                Trace.TraceInformation("Watching for batch files at {0}", watcher.Path);
-                watcher.EnableRaisingEvents = true;
+                batchDirWatcher = new FileSystemWatcher();
+                batchDirWatcher.Path = Directory.GetCurrentDirectory();
+                batchDirWatcher.Changed += Watcher_BatchDirChanged;
+                batchDirWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
+                Trace.TraceInformation("Watching for batch files at {0}", batchDirWatcher.Path);
+                batchDirWatcher.EnableRaisingEvents = true;
             }
             catch(Exception ex) {
-                Trace.TraceError("Failed to watch for batch files");
-                Trace.TraceError(ex.ToString());
+                Trace.TraceError("Failed to watch for batch files: {0}", ex.ToString());
             }
         }
 
-        private void Watcher_Changed(object sender, FileSystemEventArgs e) {
+        private void Watcher_BatchDirChanged(object sender, FileSystemEventArgs e) {
             if(e.ChangeType == WatcherChangeTypes.Changed || e.ChangeType == WatcherChangeTypes.Created) {
                 string filename = e.Name.ToLower();
                 foreach(string watchedFilename in BATCH_FILENAMES) {
                     if (filename.Equals(watchedFilename)) {
                         DateTime now = DateTime.Now;
-                        if (now.Ticks - lastChangeDt.Ticks >= FILE_CHANGE_DEBOUNCE_TIME_TICKS) {
+                        if (now.Ticks - batchDirLastChangeDt.Ticks >= FILE_CHANGE_DEBOUNCE_TIME_TICKS) {
                             skyrimInterop.SubmitCommand("COMMAND|bat " + watchedFilename);
                         }
-                        lastChangeDt = now;
+                        batchDirLastChangeDt = now;
                     }
                 }
             }
+        }
+
+        private void ListenForConfigFile()
+        {
+            try
+            {
+                string filePath = config.GetIniFilePath();
+                if (filePath == null) {
+                    throw new Exception("Configuration file does not exist.");
+                }
+
+                configFileName = Path.GetFileName(filePath).ToLower();
+
+                configFileWatcher = new FileSystemWatcher();
+                configFileWatcher.Path = Path.GetDirectoryName(filePath);
+                configFileWatcher.Changed += Watcher_ConfigFileChanged;
+                configFileWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
+                Trace.TraceInformation("Watching for config file at {0}", configFileWatcher.Path);
+                configFileWatcher.EnableRaisingEvents = true;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("Failed to watch for config files: {0}", ex.ToString());
+            }
+        }
+
+        private void Watcher_ConfigFileChanged(object sender, FileSystemEventArgs e)
+        {
+            if (!isConfigFileChanged &&
+                (e.ChangeType == WatcherChangeTypes.Changed || e.ChangeType == WatcherChangeTypes.Created))
+            {
+                string filename = e.Name.ToLower();
+                if (filename.Equals(configFileName))
+                {
+                    Trace.TraceInformation("Config file {0} changed", filename);
+                    isConfigFileChanged = true;
+
+                    Stop();
+                    skyrimInterop.Stop();
+                }
+            }
+        }
+
+        public bool IsConfigFileChanged() {
+            return isConfigFileChanged;
         }
     }
 }

--- a/dsn_service/dsn_service/ExternalInterop.cs
+++ b/dsn_service/dsn_service/ExternalInterop.cs
@@ -101,8 +101,11 @@ namespace DSN {
                 if (filename.Equals(configFileName))
                 {
                     Trace.TraceInformation("Config file {0} changed", filename);
-                    isConfigFileChanged = true;
 
+                    // Wait for the configuration file to be saved
+                    Thread.Sleep(1000);
+
+                    isConfigFileChanged = true;
                     Stop();
                     skyrimInterop.Stop();
                 }

--- a/dsn_service/dsn_service/ExternalInterop.cs
+++ b/dsn_service/dsn_service/ExternalInterop.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 namespace DSN {
     class ExternalInterop {
 
-        Configuration config = null;
-        SkyrimInterop skyrimInterop = null;
+        private Configuration config = null;
+        private SkyrimInterop skyrimInterop = null;
 
         private readonly HashSet<string> BATCH_FILENAMES = new HashSet<string>() { "wotv", "ivrqs" };
         private readonly long FILE_CHANGE_DEBOUNCE_TIME_TICKS = 10000 * 200; // 200 ms

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -154,29 +154,53 @@ namespace DSN {
         }
 
         public string GetCommandForResult(RecognitionResult result) {
-            var handednessMap = new Dictionary<string, string>
+            var mainHandMap = new Dictionary<string, string>
             {
                 { bothHandsSuffix, "0" },
                 { rightHandSuffix, "1" },
                 { leftHandSuffix, "2" },
+
+                // Comment of `mainHand` in `DragonbornSpeaksNaturally.SAMPLE.ini` said:
+                // > Valid values are "right", "left", "both"
+                // We should keep the compatibility to prevent user confusion.
+                { "both", "0" },
+                { "right", "1" },
+                { "left", "2" },
             };
 
             Grammar grammar = result.Grammar;
             if (commandsByGrammar.ContainsKey(grammar)) {
                 string command = commandsByGrammar[grammar];
-                string lastToken = result.Text.Split(' ').Last();
 
-                // Did the user ask to put the item in a specific hand?
-                if(handednessMap.ContainsKey(lastToken)) {
-                    command += handednessMap[lastToken];
-                } else if (handednessMap.ContainsKey(mainHand)) { 
+                // Determine handedness
+                //
+                // NOTICE: Some languages (such as Chinese) do not use spaces to separate words.
+                // So the code such as `result.Text.Split(' ').Last()` will not work for them.
+                // Be aware of this when changing the code below.
+                //
+                if (result.Text.EndsWith(bothHandsSuffix))
+                {
+                    command += "0";
+                }
+                else if(result.Text.EndsWith(rightHandSuffix))
+                {
+                    command += "1";
+                }
+                else if (result.Text.EndsWith(leftHandSuffix))
+                {
+                    command += "2";
+                }
+                else if (mainHandMap.ContainsKey(mainHand))
+                {
                     // The user didn't ask for a specific hand, supply a user specified default
-                    command += handednessMap[mainHand];
-                } else {
+                    command += mainHandMap[mainHand];
+                }
+                else
+                {
                     // Try equipping the item in both hands as a last resort
                     command += "0";
                 }
-                
+
                 return command;
             }
 

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -11,7 +11,7 @@ using System.IO;
 namespace DSN {
     class FavoritesList : ISpeechRecognitionGrammarProvider {
 
-        Configuration config;
+        private Configuration config;
         private Dictionary<Grammar, string> commandsByGrammar;
         private string leftHandSuffix;
         private string rightHandSuffix;

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -111,8 +111,6 @@ namespace DSN {
            
             dynamic itemNameMap = LoadItemNameMap();
 
-            Trace.TraceInformation("Received favorites list: {0}", input);
-
             string equipPrefix = config.Get("Favorites", "equipPhrasePrefix", "equip");
             commandsByGrammar.Clear();
             string[] itemTokens = input.Split('|');

--- a/dsn_service/dsn_service/FavoritesList.cs
+++ b/dsn_service/dsn_service/FavoritesList.cs
@@ -11,11 +11,22 @@ using System.IO;
 namespace DSN {
     class FavoritesList : ISpeechRecognitionGrammarProvider {
 
-        private  Dictionary<Grammar, string> commandsByGrammar = new Dictionary<Grammar, string>();
-        private string leftHandSuffix = Configuration.Get("Favorites", "equipLeftSuffix", "left");
-        private string rightHandSuffix = Configuration.Get("Favorites", "equipRightSuffix", "right");
-        private string bothHandsSuffix = Configuration.Get("Favorites", "equipBothSuffix", "both");
-        private string mainHand = Configuration.Get("Favorites", "mainHand", "none");
+        Configuration config;
+        private Dictionary<Grammar, string> commandsByGrammar;
+        private string leftHandSuffix;
+        private string rightHandSuffix;
+        private string bothHandsSuffix;
+        private string mainHand;
+
+        public FavoritesList(Configuration config) {
+            this.config = config;
+
+            commandsByGrammar = new Dictionary<Grammar, string>();
+            leftHandSuffix = config.Get("Favorites", "equipLeftSuffix", "left");
+            rightHandSuffix = config.Get("Favorites", "equipRightSuffix", "right");
+            bothHandsSuffix = config.Get("Favorites", "equipBothSuffix", "both");
+            mainHand = config.Get("Favorites", "mainHand", "none");
+        }
 
         private HashSet<string> knownEquipmentTypes = new HashSet<string>
         {
@@ -58,7 +69,7 @@ namespace DSN {
         // Returns dynamic map/dictionary or null when the replacement map files cannot be located
         public dynamic LoadItemNameMap()
         {
-            string filepath = Configuration.resolveFilePath("item-name-map.json");
+            string filepath = config.resolveFilePath("item-name-map.json");
             if(File.Exists(filepath))
             {
                 return LoadItemNameMap(filepath);
@@ -92,7 +103,7 @@ namespace DSN {
  
 
         public void Update(string input) {
-            if(Configuration.Get("Favorites", "enabled", "1") == "0") {
+            if(config.Get("Favorites", "enabled", "1") == "0") {
                 return;
             }
 
@@ -102,7 +113,7 @@ namespace DSN {
 
             Trace.TraceInformation("Received favorites list: {0}", input);
 
-            string equipPrefix = Configuration.Get("Favorites", "equipPhrasePrefix", "equip");
+            string equipPrefix = config.Get("Favorites", "equipPhrasePrefix", "equip");
             commandsByGrammar.Clear();
             string[] itemTokens = input.Split('|');
             foreach(string itemStr in itemTokens) {

--- a/dsn_service/dsn_service/Program.cs
+++ b/dsn_service/dsn_service/Program.cs
@@ -27,15 +27,19 @@ namespace DSN {
                     }
                 }
 
-                Thread skyrimThread = SkyrimInterop.Start();
-                Thread externalThread = ExternalInterop.Start();
+                Configuration config = new Configuration();
+                SkyrimInterop skyrimInterop = new SkyrimInterop(config);
+                ExternalInterop externalInterop = new ExternalInterop(skyrimInterop);
+
+                Thread skyrimThread = skyrimInterop.Start();
+                Thread externalThread = externalInterop.Start();
 
                 // Skyrim thread will finish when Skyrim closes
                 skyrimThread.Join();
 
                 // Cleanup threads
-                SkyrimInterop.Stop();
-                ExternalInterop.Stop();
+                skyrimInterop.Stop();
+                externalInterop.Stop();
                 externalThread.Abort();
 
             } catch (Exception ex) {

--- a/dsn_service/dsn_service/SkyrimInterop.cs
+++ b/dsn_service/dsn_service/SkyrimInterop.cs
@@ -85,6 +85,9 @@ namespace DSN {
 
         private void ListenForInput() {
             try {
+                // try to restore saved state after reloading the configuration file.
+                consoleInput.RestoreSavedState();
+
                 while (true) {
                     string input = consoleInput.ReadLine();
 
@@ -98,18 +101,21 @@ namespace DSN {
                     string[] tokens = input.Split('|');
                     string command = tokens[0];
                     if (command.Equals("START_DIALOGUE")) {
+                        consoleInput.currentDialogue = input;
                         lock (dialogueLock) {
                             currentDialogue = DialogueList.Parse(string.Join("|", tokens, 1, tokens.Length - 1), config);
                         }
                         // Switch to dialogue mode
                         recognizer.StartSpeechRecognition(true, currentDialogue);
                     } else if (command.Equals("STOP_DIALOGUE")) {
+                        consoleInput.currentDialogue = null;
                         // Switch to command mode
                         recognizer.StartSpeechRecognition(false, config.GetConsoleCommandList(), favoritesList);
                         lock (dialogueLock) {
                             currentDialogue = null;
                         }
                     } else if (command.Equals("FAVORITES")) {
+                        consoleInput.currentFavoritesList = input;
                         favoritesList.Update(string.Join("|", tokens, 1, tokens.Length - 1));
                         if(currentDialogue == null) {
                             recognizer.StartSpeechRecognition(false, config.GetConsoleCommandList(), favoritesList);

--- a/dsn_service/dsn_service/SpeechRecognitionManager.cs
+++ b/dsn_service/dsn_service/SpeechRecognitionManager.cs
@@ -70,7 +70,7 @@ namespace DSN {
                 for (; ; ) {
                     try {
                         this.DSN.SetInputToDefaultAudioDevice();
-                        Trace.TraceInformation("The recording device is ready.");
+                        Trace.TraceInformation("The recording device is ready, recognition started.");
                         break;
                     } catch (System.InvalidOperationException) {
                         if (!logWaitingRecDev) {

--- a/dsn_service/dsn_service/SpeechRecognitionManager.cs
+++ b/dsn_service/dsn_service/SpeechRecognitionManager.cs
@@ -50,6 +50,7 @@ namespace DSN {
             if (waitingDeviceThread != null) {
                 waitingDeviceThread.Abort();
             }
+            StopRecognition();
         }
 
         private void WaitRecordingDeviceNonBlocking() {

--- a/dsn_service/dsn_service/SpeechRecognitionManager.cs
+++ b/dsn_service/dsn_service/SpeechRecognitionManager.cs
@@ -24,11 +24,14 @@ namespace DSN {
         private ISpeechRecognitionGrammarProvider[] grammarProviders;
 
         private Thread waitingDeviceThread;
+        private Configuration config;
 
-        public SpeechRecognitionManager() {
-            string locale = Configuration.Get("SpeechRecognition", "Locale", CultureInfo.InstalledUICulture.Name);
-            dialogueMinimumConfidence = float.Parse(Configuration.Get("SpeechRecognition", "dialogueMinConfidence", "0.5"), CultureInfo.InvariantCulture);
-            commandMinimumConfidence = float.Parse(Configuration.Get("SpeechRecognition", "commandMinConfidence", "0.7"), CultureInfo.InvariantCulture);
+        public SpeechRecognitionManager(Configuration config) {
+            this.config = config;
+
+            string locale = config.Get("SpeechRecognition", "Locale", CultureInfo.InstalledUICulture.Name);
+            dialogueMinimumConfidence = float.Parse(config.Get("SpeechRecognition", "dialogueMinConfidence", "0.5"), CultureInfo.InvariantCulture);
+            commandMinimumConfidence = float.Parse(config.Get("SpeechRecognition", "commandMinConfidence", "0.7"), CultureInfo.InvariantCulture);
 
             Trace.TraceInformation("Locale: {0}\nDialogueConfidence: {1}\nCommandConfidence: {2}", locale, dialogueMinimumConfidence, commandMinimumConfidence);
 
@@ -91,7 +94,7 @@ namespace DSN {
         }
 
         private void DSN_AudioStateChanged(object sender, AudioStateChangedEventArgs e) {
-            if (Configuration.Get("SpeechRecognition", "bLogAudioSignalIssues", "0") == "1") {
+            if (config.Get("SpeechRecognition", "bLogAudioSignalIssues", "0") == "1") {
                 Trace.TraceInformation("Audio state changed: {0}", e.AudioState.ToString());
             }
 
@@ -103,7 +106,7 @@ namespace DSN {
         }
 
         private void DSN_AudioSignalProblemOccurred(object sender, AudioSignalProblemOccurredEventArgs e) {
-            if(Configuration.Get("SpeechRecognition", "bLogAudioSignalIssues", "0") == "1") {
+            if(config.Get("SpeechRecognition", "bLogAudioSignalIssues", "0") == "1") {
                 Trace.TraceInformation("Audio signal problem occurred during speech recognition: {0}", e.AudioSignalProblem.ToString());
             }
         }

--- a/dsn_service/dsn_service/dsn_service.csproj
+++ b/dsn_service/dsn_service/dsn_service.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandList.cs" />
+    <Compile Include="ConsoleInput.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="ExternalInterop.cs" />
     <Compile Include="FavoritesList.cs" />


### PR DESCRIPTION
What's New:
* Automatically reload the configuration file. You do not have to restart the game after modifying the configuration file. All modifications will take effect immediately after saving.
* Added a new option `useEquipHandPrefix` to the favorites menu voice-equip:
```
; Consider the above equipLeft/Right/BothSuffix as a prefix instead of a suffix.
; If enabled, equip phrases will be "off/main/both equip xxx" instead of "equip xxx off/main/both".
; Open according to your preferences. This may be more convenient in some languages.
; In addition, you can set equipPhrasePrefix to empty to make better use of hands prefix.
useEquipHandPrefix=0
```
* Add more examples and documentation links to the configuration sample. [Preview the configuration](https://github.com/YihaoPeng/DragonbornSpeaksNaturally/blob/master/DragonbornSpeaksNaturally.SAMPLE.ini)

Fixed:
* Fix hand suffix not work in Chinese lauguage.
* Fix "valid values" of `mainHand` not work.
